### PR TITLE
Adding new section checks for 2026 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ This action runs several checks on the software repository submitted for review 
 The action also looks for a `paper.md` file in the specified repository and post back information on:
 
 - **Wordcount**: This will count the number of words in the paper file.
-- **Detect statement of need**: This check will look for an `Statement of need` section in the paper content.
+- **Detect statement of need**: This check will look for a `Statement of need` section in the paper content.
+- **Detect software design section**: For submissions without the `pre-2026-submission` label, this check will look for a `Software Design` section in the paper.
+- **Detect research impact statement**: For submissions without the `pre-2026-submission` label, this check will look for a `Research Impact Statement` section in the paper.
+- **Detect AI usage disclosure**: For submissions without the `pre-2026-submission` label, this check will look for an `AI usage disclosure` section in the paper.
 
 
 ## Usage

--- a/checks.rb
+++ b/checks.rb
@@ -409,8 +409,6 @@ else
 
   # Count paper file length
   word_count = Open3.capture3("cat #{paper_path} | wc -w")[0].to_i
-  word_count_icon = word_count > 1999 ? "🚨" : (word_count > 1200 ? "⚠️" : "📄")
-  word_count_msg = "#{word_count_icon} Wordcount for `#{File.basename(paper_path)}` is **#{word_count}**"
 
   # Read paper content once
   paper_file_text = File.open(paper_path).read
@@ -418,6 +416,16 @@ else
   # Check if issue has pre-2026-submission label
   labels_output = Open3.capture3("gh issue view #{issue_id} --json labels --jq '.labels[].name'")[0]
   is_pre_2026 = labels_output.include?("pre-2026-submission")
+
+  # Apply different word count thresholds based on submission type
+  if is_pre_2026
+    # Pre-2026 papers: original thresholds (target ~1000-1200 words)
+    word_count_icon = word_count > 1999 ? "🚨" : (word_count > 1200 ? "⚠️" : "📄")
+  else
+    # 2026+ papers: expanded thresholds (target ~1500-1800 words)
+    word_count_icon = word_count > 1999 ? "🚨" : (word_count > 1800 ? "⚠️" : "📄")
+  end
+  word_count_msg = "#{word_count_icon} Wordcount for `#{File.basename(paper_path)}` is **#{word_count}**"
 
   # Check for required sections
 


### PR DESCRIPTION
This pull request updates the repository checks to support new paper requirements for submissions from 2026 onwards. It introduces additional section checks and adjusts word count thresholds based on the submission type, as well as improving documentation.

**Enhancements for paper section checks and word count:**

* The `build_repository_history_section` method in `checks.rb` now checks for new required sections (`Software Design`, `Research Impact Statement`, and `AI usage disclosure`) in the `paper.md` file for submissions without the `pre-2026-submission` label. It always checks for the `Statement of need` section.
* Word count thresholds are now dynamic: pre-2026 submissions use the original thresholds (target 1000–1200 words), while 2026+ submissions use expanded thresholds (target 1500–1800 words).

**Documentation updates:**

* The `README.md` has been updated to document the new checks for `Software Design`, `Research Impact Statement`, and `AI usage disclosure` sections, clarifying which are required for different submission types.