### PR TITLE
Check for "State of the field" in post-2026 submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The action also looks for a `paper.md` file in the specified repository and post
 
 - **Wordcount**: This will count the number of words in the paper file.
 - **Detect statement of need**: This check will look for a `Statement of need` section in the paper content.
+- **Detect state of the field section**: For submissions without the `pre-2026-submission` label, this check will look for a `State of the Field` section in the paper.
 - **Detect software design section**: For submissions without the `pre-2026-submission` label, this check will look for a `Software Design` section in the paper.
 - **Detect research impact statement**: For submissions without the `pre-2026-submission` label, this check will look for a `Research Impact Statement` section in the paper.
 - **Detect AI usage disclosure**: For submissions without the `pre-2026-submission` label, this check will look for an `AI usage disclosure` section in the paper.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The action also looks for a `paper.md` file in the specified repository and post
 - **Wordcount**: This will count the number of words in the paper file.
 - **Detect statement of need**: This check will look for a `Statement of need` section in the paper content.
 - **Detect state of the field section**: For submissions without the `pre-2026-submission` label, this check will look for a `State of the Field` section in the paper.
-- **Detect software design section**: For submissions without the `pre-2026-submission` label, this check will look for a `Software Design` section in the paper.
-- **Detect research impact statement**: For submissions without the `pre-2026-submission` label, this check will look for a `Research Impact Statement` section in the paper.
+- **Detect software design section**: For submissions without the `pre-2026-submission` label, this check will look for a `Software design` section in the paper.
+- **Detect research impact statement**: For submissions without the `pre-2026-submission` label, this check will look for a `Research impact statement` section in the paper.
 - **Detect AI usage disclosure**: For submissions without the `pre-2026-submission` label, this check will look for an `AI usage disclosure` section in the paper.
 
 

--- a/checks.rb
+++ b/checks.rb
@@ -447,7 +447,7 @@ else
     end
 
     # 3. Software design
-    if paper_file_text =~ /# Software Design/i
+    if paper_file_text =~ /# Software design/i
       section_checks << "✅ The paper includes a `Software design` section"
     else
       section_checks << "🔴 Failed to discover a `Software design` section in paper"

--- a/checks.rb
+++ b/checks.rb
@@ -430,7 +430,7 @@ else
   # Check for required sections
 
   # 1. Statement of need (always required)
-  if paper_file_text =~ /# Statement of Need/i
+  if paper_file_text =~ /# Statement of need/i
     statement_of_need_msg = "✅ The paper includes a `Statement of need` section"
   else
     statement_of_need_msg = "🔴 Failed to discover a `Statement of need` section in paper"
@@ -439,25 +439,25 @@ else
   # New sections (only checked if NOT pre-2026)
   section_checks = []
   unless is_pre_2026
-    # 2. State of the Field
-    if paper_file_text =~ /# State of the Field/i
-      section_checks << "✅ The paper includes a `State of the Field` section"
+    # 2. State of the field
+    if paper_file_text =~ /# State of the field/i
+      section_checks << "✅ The paper includes a `State of the field` section"
     else
-      section_checks << "🔴 Failed to discover a `State of the Field` section in paper"
+      section_checks << "🔴 Failed to discover a `State of the field` section in paper"
     end
 
-    # 3. Software Design
+    # 3. Software design
     if paper_file_text =~ /# Software Design/i
-      section_checks << "✅ The paper includes a `Software Design` section"
+      section_checks << "✅ The paper includes a `Software design` section"
     else
-      section_checks << "🔴 Failed to discover a `Software Design` section in paper"
+      section_checks << "🔴 Failed to discover a `Software design` section in paper"
     end
 
-    # 4. Research Impact Statement
-    if paper_file_text =~ /# Research Impact( Statement)?/i
-      section_checks << "✅ The paper includes a `Research Impact Statement` section"
+    # 4. Research impact statement
+    if paper_file_text =~ /# Research impact( statement)?/i
+      section_checks << "✅ The paper includes a `Research impact statement` section"
     else
-      section_checks << "🔴 Failed to discover a `Research Impact Statement` section in paper"
+      section_checks << "🔴 Failed to discover a `Research impact statement` section in paper"
     end
 
     # 5. AI usage disclosure

--- a/checks.rb
+++ b/checks.rb
@@ -439,21 +439,28 @@ else
   # New sections (only checked if NOT pre-2026)
   section_checks = []
   unless is_pre_2026
-    # 2. Software Design
+    # 2. State of the Field
+    if paper_file_text =~ /# State of the Field/i
+      section_checks << "✅ The paper includes a `State of the Field` section"
+    else
+      section_checks << "🔴 Failed to discover a `State of the Field` section in paper"
+    end
+
+    # 3. Software Design
     if paper_file_text =~ /# Software Design/i
       section_checks << "✅ The paper includes a `Software Design` section"
     else
       section_checks << "🔴 Failed to discover a `Software Design` section in paper"
     end
 
-    # 3. Research Impact Statement
+    # 4. Research Impact Statement
     if paper_file_text =~ /# Research Impact( Statement)?/i
       section_checks << "✅ The paper includes a `Research Impact Statement` section"
     else
       section_checks << "🔴 Failed to discover a `Research Impact Statement` section in paper"
     end
 
-    # 4. AI usage disclosure
+    # 5. AI usage disclosure
     if paper_file_text =~ /# AI (usage|use) disclosure/i
       section_checks << "✅ The paper includes an `AI usage disclosure` section"
     else


### PR DESCRIPTION
As noted in https://github.com/openjournals/joss/pull/1498, the JOSS docs currently have a mix of advice on whether the "State of the field" section is required. For parity with that PR, this would add a check to the `@editorialbot check repository` command.

Also, like that PR, this one tries to imply some consistency in section casing (sentence case rather than title case).